### PR TITLE
Brak linku do działu źródłowego w ramce ostrzegawczej #176

### DIFF
--- a/resources/views/forum/topic.twig
+++ b/resources/views/forum/topic.twig
@@ -18,7 +18,7 @@
 
     {% if warnings.move %}
         <p class="alert alert-warning">
-            Wątek przeniesiony {{ warnings.move.created_at|format_date }} z {{ warnings.move.object.forum.name }} przez <a class="alert-link" href="{{ url(warnings.move.actor.url) }}">{{ warnings.move.actor.displayName }}</a>.
+            Wątek przeniesiony {{ warnings.move.created_at|format_date }} z <a href="{{ route('forum.category', [warnings.move.object.forum.slug]) }}">{{ warnings.move.object.forum.name }}</a> przez <a class="alert-link" href="{{ url(warnings.move.actor.url) }}">{{ warnings.move.actor.displayName }}</a>.
 
             {% if warnings.move.object.reasonName %}
                 Powód: <strong>{{ warnings.move.object.reasonName }}</strong>

--- a/resources/views/forum/topic.twig
+++ b/resources/views/forum/topic.twig
@@ -18,7 +18,7 @@
 
     {% if warnings.move %}
         <p class="alert alert-warning">
-            Wątek przeniesiony {{ warnings.move.created_at|format_date }} z <a href="{{ route('forum.category', [warnings.move.object.forum.slug]) }}">{{ warnings.move.object.forum.name }}</a> przez <a class="alert-link" href="{{ url(warnings.move.actor.url) }}">{{ warnings.move.actor.displayName }}</a>.
+            Wątek przeniesiony {{ warnings.move.created_at|format_date }} z <a class="alert-link" href="{{ route('forum.category', [warnings.move.object.forum.slug]) }}">{{ warnings.move.object.forum.name }}</a> przez <a class="alert-link" href="{{ url(warnings.move.actor.url) }}">{{ warnings.move.actor.displayName }}</a>.
 
             {% if warnings.move.object.reasonName %}
                 Powód: <strong>{{ warnings.move.object.reasonName }}</strong>


### PR DESCRIPTION
Zgodnie z treścią #176 dodano link do kategorii źródłowej tematu: https://dl.dropboxusercontent.com/u/435780/Zrzut%20ekranu%20z%202017-01-01%2018-05-00.png  