### PR TITLE
Pusta zakładka "Mikroblog" 

### DIFF
--- a/resources/assets/sass/pages/profile.scss
+++ b/resources/assets/sass/pages/profile.scss
@@ -142,3 +142,10 @@
   max-height: 280px;
   overflow: hidden;
 }
+
+.well.empty-result {
+  background-position: center left;
+  margin-bottom: 0;
+  min-height: 68px;
+  padding: 12px 0;
+}

--- a/resources/views/profile/partials/microblog.twig
+++ b/resources/views/profile/partials/microblog.twig
@@ -1,9 +1,23 @@
 <section id="microblog" class="box">
-    {% for microblog in microblogs %}
-        {% include "microblog.partials.microblog" %}
-    {% endfor %}
+    {% if microblogs is not empty %}
+        {% for microblog in microblogs %}
+            {% include "microblog.partials.microblog" %}
+        {% endfor %}
 
-    <div class="text-center">
-        {{ pagination|raw }}
-    </div>
+        <div class="text-center">
+            {{ pagination|raw }}
+        </div>
+    {% else %}
+        <div class="panel panel-default">
+            <div class="panel-body">
+                <div class="row">
+                    <div class="col-xs-12">
+                        <div class="well well-sm empty-result">
+                            <p>Użytkownik nie opublikował ani jednego wpisu na mikroblogu.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 </section>


### PR DESCRIPTION
Trochę "łyso" wygląda pusta zakładka "Mikroblog" w profilu więc dodałem stosowny komunikat, analogiczny do tego kiedy użytkownik nie ma żadnych punktów reputacji.  Zrzut ekranu: https://dl.dropboxusercontent.com/u/435780/Zrzut%20ekranu%20z%202017-01-13%2022-46-43.png



