### PR TITLE
Add some simple styles for tables in articles

### DIFF
--- a/resources/assets/sass/components/_tables.scss
+++ b/resources/assets/sass/components/_tables.scss
@@ -3,6 +3,27 @@
 // Darker links in table
 // ------------------------------------
 
-table {
-  @include link-color-darker;
+article {
+  table {
+    @include link-color-darker;
+
+    width: 100%;
+
+    thead {
+      border: 1px solid #bbbbbb;
+      background-color: #cccccc;
+      th {
+        border: 1px solid #bbbbbb;
+        padding: $table-cell-padding;
+      }
+    }
+    tbody {
+      tr {
+        td {
+          border: 1px solid #cccccc;
+          padding: $table-cell-padding;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Dodałem proste style dla tabel w artykułach. Obecnie są pozbawione jakiegokolwiek stylu i zlewają się z treścią. Nie mam 100% pewności, że to zadziała jak ma zadziałać, ale na pewno jest lepiej niż obecnie. 