### PR TITLE
Wysyłanie formularza za pomocą ⌘+Enter

### DIFF
--- a/resources/assets/js/plugins/fast-submit.js
+++ b/resources/assets/js/plugins/fast-submit.js
@@ -8,7 +8,7 @@
                     let form = $(this).closest('form');
                     let isDisabled = form.find(':submit').attr('disabled') === 'disabled';
 
-                    if (e.ctrlKey && !isDisabled) {
+                    if ((e.ctrlKey || e.metaKey) && !isDisabled) {
                         form.submit();
                     }
                 }


### PR DESCRIPTION
Zmienia fast-submit, aby oprócz ctrl+enter dostępny był również metakey+enter (klawisz command na MacOS, klawisz Start/Windows na Windows - najwyraźniej poza Firefox, patrz https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey).

Za: https://4programmers.net/Forum/Coyote/326452-mozliwosc_uzycia_enter_zamiast_ctrlenter_na_macu

Wymaga przetestowania!