### PR TITLE
Próba naprawienia buga z nawiasami w linkach

### DIFF
--- a/app/Services/Parser/Parsers/Link.php
+++ b/app/Services/Parser/Parsers/Link.php
@@ -42,7 +42,7 @@ class Link extends Parser implements ParserInterface
         $this->page = $page;
         $this->host = $host;
         $this->html = $html;
-        $this->urlParser = new UrlFormatter($host);
+        $this->urlParser = new UrlFormatter($host, app('html'));
     }
 
     /**

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Coyote\Services\Parser\Parsers;
+
+use Collective\Html\HtmlBuilder;
 
 class UrlFormatter
 {
@@ -11,13 +14,16 @@ class UrlFormatter
 
     /** @var string */
     private $host;
+    /** @var HtmlBuilder */
+    private $html;
 
-    public function __construct(string $host)
+    public function __construct(string $host, HtmlBuilder $html)
     {
         $this->host = $host;
+        $this->html = $html;
     }
 
-    public function parse(string $text):string
+    public function parse(string $text): string
     {
 
         $processed = preg_replace_callback(
@@ -31,7 +37,7 @@ class UrlFormatter
 
                 $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
 
-                return link_to($url, $title);
+                return $this->html->link($url, $title);
             },
             $text
         );

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -7,10 +7,10 @@ use Collective\Html\HtmlBuilder;
 class UrlFormatter
 {
     // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
-    const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
+    private const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
 
-    const TITLE_LEN = 64;
-    const TITLE_DOTS = '[...]';
+    private const TITLE_LEN = 64;
+    private const TITLE_DOTS = '[...]';
 
     /** @var string */
     private $host;
@@ -53,15 +53,9 @@ class UrlFormatter
         return $text;
     }
 
-    /**
-     * @param string $text
-     * @param int $length
-     * @param string $dots
-     * @return string
-     */
-    private function truncate(string $text, int $length = self::TITLE_LEN, string $dots = self::TITLE_DOTS): string
+    private function truncate(string $text): string
     {
-        if (mb_strlen($text) < $length) {
+        if (mb_strlen($text) < self::TITLE_LEN) {
             return $text;
         }
 
@@ -69,10 +63,10 @@ class UrlFormatter
             return $text;
         }
 
-        $padding = ($length - mb_strlen($dots)) / 2;
+        $padding = (self::TITLE_LEN - mb_strlen(self::TITLE_DOTS)) / 2;
 
         $result = mb_substr($text, 0, $padding);
-        $result .= $dots;
+        $result .= self::TITLE_DOTS;
         $result .= mb_substr($text, -$padding);
 
         return $result;

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -58,12 +58,12 @@ class UrlFormatter
             return $text;
         }
 
-        $padding = (self::TITLE_LEN - mb_strlen(self::TITLE_DOTS)) / 2;
+        return $this->truncateToLengthWith($text, self::TITLE_LEN, self::TITLE_DOTS);
+    }
 
-        $result = mb_substr($text, 0, $padding);
-        $result .= self::TITLE_DOTS;
-        $result .= mb_substr($text, -$padding);
-
-        return $result;
+    private function truncateToLengthWith(string $text, int $length, string $substitute): string
+    {
+        $padding = ($length - mb_strlen($substitute)) / 2;
+        return mb_substr($text, 0, $padding) . $substitute . mb_substr($text, -$padding);
     }
 }

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -12,7 +12,6 @@ class UrlFormatter
     private const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
 
     private const TITLE_LEN = 64;
-    private const TITLE_DOTS = '[...]';
 
     /** @var string */
     private $host;
@@ -28,16 +27,12 @@ class UrlFormatter
     public function parse(string $text): string
     {
         try {
-            return preg::replace_callback(self::REGEXP_URL, function ($match) {
+            return preg::replace_callback(self::REGEXP_URL, function (array $match): string {
                 $url = $match[0];
-
-                if (!preg_match('#^[\w]+?://.*?#i', $url)) {
-                    $url = 'http://' . $url;
+                if (pattern('^[\w]+?://', 'i')->fails($url)) {
+                    return $this->processLink('http://' . $url, $url);
                 }
-
-                $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
-
-                return $this->html->link($url, $title);
+                return $this->processLink($url, $url);
             }, $text);
         } catch (BacktrackLimitPregException $exception) {
             // regexp posiada buga, nie parsuje poprawnie URL-i jezeli zawiera on (
@@ -48,17 +43,21 @@ class UrlFormatter
         }
     }
 
+    private function processLink(string $url, string $title): string
+    {
+        $quoted = htmlspecialchars($title, ENT_QUOTES, 'UTF-8', false); // doesn't app('html') take care of this?
+        return $this->html->link($url, $this->truncate($quoted));
+    }
+
     private function truncate(string $text): string
     {
         if (mb_strlen($text) < self::TITLE_LEN) {
             return $text;
         }
-
         if ($this->host === parse_url($text, PHP_URL_HOST)) {
             return $text;
         }
-
-        return $this->truncateToLengthWith($text, self::TITLE_LEN, self::TITLE_DOTS);
+        return $this->truncateToLengthWith($text, self::TITLE_LEN, '[...]');
     }
 
     private function truncateToLengthWith(string $text, int $length, string $substitute): string

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -1,0 +1,74 @@
+<?php
+namespace Coyote\Services\Parser\Parsers;
+
+class UrlFormatter
+{
+    // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+    const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
+
+    const TITLE_LEN = 64;
+    const TITLE_DOTS = '[...]';
+
+    /** @var string */
+    private $host;
+
+    public function __construct(string $host)
+    {
+        $this->host = $host;
+    }
+
+    public function parse(string $text):string
+    {
+
+        $processed = preg_replace_callback(
+            self::REGEXP_URL,
+            function ($match) {
+                $url = $match[0];
+
+                if (!preg_match('#^[\w]+?://.*?#i', $url)) {
+                    $url = 'http://' . $url;
+                }
+
+                $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
+
+                return link_to($url, $title);
+            },
+            $text
+        );
+
+        // regexp posiada buga, nie parsuje poprawnie URL-i jezeli zawiera on (
+        // poki co nie mam rozwiazania na ten problem, dlatego zwracamy nieprzeprasowany tekst
+        // w przypadku bledu
+        // Dokłądniej mówiąc to nie parsuje żadnego urla w poście, jeśli przynajmniej jeden z nich ma (
+        if (preg_last_error() === PREG_NO_ERROR) {
+            return $processed;
+        }
+
+        return $text;
+    }
+
+    /**
+     * @param string $text
+     * @param int $length
+     * @param string $dots
+     * @return string
+     */
+    private function truncate(string $text, int $length = self::TITLE_LEN, string $dots = self::TITLE_DOTS): string
+    {
+        if (mb_strlen($text) < $length) {
+            return $text;
+        }
+
+        if ($this->host === parse_url($text, PHP_URL_HOST)) {
+            return $text;
+        }
+
+        $padding = ($length - mb_strlen($dots)) / 2;
+
+        $result = mb_substr($text, 0, $padding);
+        $result .= $dots;
+        $result .= mb_substr($text, -$padding);
+
+        return $result;
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -100,6 +100,22 @@ class UrlFormatterTest extends TestCase
         $this->assertEquals('<a>4pr.net/Forum/</a>(tex(t)', $result);
     }
 
+    /**
+     * @test
+     */
+    public function shouldHandleCatastrophicBacktracking_withUnmatchedParenthesis()
+    {
+        // given
+        $errorProneLink = 'http://4pr.net/Forum/(long_long_long_long_long';
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+
+        // when
+        $result = $formatter->parse($errorProneLink);
+
+        // then
+        $this->assertEquals('<a>http://4pr.net/Forum/</a>(long_long_long_long_long', $result);
+    }
+
     private function html(string $expectedHref = null): HtmlBuilder
     {
         /** @var HtmlBuilder|MockObject $html */

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Services\Parser\Parsers;
+
+use Collective\Html\HtmlBuilder;
+use Coyote\Services\Parser\Parsers\UrlFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UrlFormatterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldParseLink()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldTruncateLongLink()
+    {
+        // given
+        $longUrl = 'https://scrutinizer-ci.com/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
+        $formatter = new UrlFormatter('', $this->html($longUrl));
+
+        // when
+        $result = $formatter->parse("link: $longUrl");
+
+        // then
+        $this->assertEquals('link: <a>https://scrutinizer-ci.com/g/[...]8-ef73-4167-8092-424a57a8e66d</a>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldIncludeParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(text) text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(text)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldIncludeNestedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(t(ex)t)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(t(ex)t) text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(t(ex)t)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotIncludeUnmatchedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(text)( text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(text)</a>( text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotIncludeUnmatchedNestedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+
+        // when
+        $result = $formatter->parse('4pr.net/Forum/(tex(t)');
+
+        // then
+        $this->assertEquals('<a>4pr.net/Forum/</a>(tex(t)', $result);
+    }
+
+    private function html(string $expectedHref = null): HtmlBuilder
+    {
+        /** @var HtmlBuilder|MockObject $html */
+        $html = $this->createMock(HtmlBuilder::class);
+        $html
+            ->expects($this->once())
+            ->method('link')
+            ->will($this->returnCallback(function (string $href, string $title) use ($expectedHref): string {
+                if ($expectedHref) {
+                    $this->assertEquals($expectedHref, $href, 'Failed asserting that parsed link contains expected href attribute');
+                }
+                return "<a>$title</a>";
+            }));
+        return $html;
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -27,6 +27,21 @@ class UrlFormatterTest extends TestCase
     /**
      * @test
      */
+    public function shouldParseLink_htmlEntities()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum&param'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum&param text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum&amp;param</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
     public function shouldTruncateLongLink()
     {
         // given
@@ -69,6 +84,21 @@ class UrlFormatterTest extends TestCase
 
         // then
         $this->assertEquals('text <a>4pr.net/Forum/(text)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldHandleLinksSeparatedByAnOpenParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum', 2));
+
+        // when
+        $result = $formatter->parse('4pr.net/Forum(4pr.net/Forum');
+
+        // then
+        $this->assertEquals('<a>4pr.net/Forum</a>(<a>4pr.net/Forum</a>', $result);
     }
 
     /**
@@ -132,12 +162,12 @@ class UrlFormatterTest extends TestCase
         $this->assertEquals('<a>http://4pr.net/Forum/</a>(long_long_long_long_long', $result);
     }
 
-    private function html(string $expectedHref = null): HtmlBuilder
+    private function html(string $expectedHref = null, int $expectedInvocations = 1): HtmlBuilder
     {
         /** @var HtmlBuilder|MockObject $html */
         $html = $this->createMock(HtmlBuilder::class);
         $html
-            ->expects($this->once())
+            ->expects($this->exactly($expectedInvocations))
             ->method('link')
             ->will($this->returnCallback(function (string $href, string $title) use ($expectedHref): string {
                 if ($expectedHref) {

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -43,6 +43,22 @@ class UrlFormatterTest extends TestCase
     /**
      * @test
      */
+    public function shouldNotTruncateLongLink_hostLink()
+    {
+        // given
+        $longUrl = 'https://4pr.net/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
+        $formatter = new UrlFormatter('4pr.net', $this->html($longUrl));
+
+        // when
+        $result = $formatter->parse("link: $longUrl");
+
+        // then
+        $this->assertEquals('link: <a>https://4pr.net/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d</a>', $result);
+    }
+
+    /**
+     * @test
+     */
     public function shouldIncludeParenthesis()
     {
         // given

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -151,6 +151,8 @@ class UrlFormatterTest extends TestCase
      */
     public function shouldHandleCatastrophicBacktracking_withUnmatchedParenthesis()
     {
+        $this->markTestSkipped("Bug in UrlFormatter fails to parse links with too much characters after (");
+
         // given
         $errorProneLink = 'http://4pr.net/Forum/(long_long_long_long_long';
         $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));


### PR DESCRIPTION
- Napisałem unity pod parser linków w phpUnit w `/tests/Feature` zgodnie z umówą
- Wyniosłem logikę parsowania linków z `Links` do klasy pod którą są te unity właśnie
- Napisałem test ilustrujący buga, który teraz jest skipped, będzie naprawiony w kolejnym PRze
- Użyłem libki z poprzedniego PRa, która rzuciła `BacktrackLimitPregException`, czyli to by znaczyło że bug występuje tylko jak jest zbyt dużo znaków za `(`, czyli np linki `4p.net/(aa` (dwa znaki po `(`) powinny działać, bo tyle backtracking jest w stanie "dźwignąć". wyżej 10 znaków po `(` parser klęka.

Po merge'u wrzucę jeszcze drugi PR z fixinętym testem.