### PR TITLE
Implement link parsing

### DIFF
--- a/app/Services/Parser/Parsers/Link.php
+++ b/app/Services/Parser/Parsers/Link.php
@@ -4,6 +4,8 @@ namespace Coyote\Services\Parser\Parsers;
 
 use Collective\Html\HtmlBuilder;
 use Coyote\Repositories\Contracts\PageRepositoryInterface as PageRepository;
+use Coyote\Services\Parser\Parsers\Parentheses\ParenthesesParser;
+use Coyote\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunks;
 
 class Link extends Parser implements ParserInterface
 {
@@ -11,6 +13,8 @@ class Link extends Parser implements ParserInterface
     const LINK_INTERNAL_REGEXP = '\[\[(.*?)(\|(.*?))*\]\]';
 
     const REGEXP_EMAIL = '#(^|[\n \[\]\:<>&;]|\()([a-z0-9&\-_.]+?@[\w\-]+\.(?:[\w\-\.]+\.)?[\w]+)#i';
+
+    private const PARENTHESES_LEVEL = 3;
 
     /**
      * @var PageRepository
@@ -42,7 +46,7 @@ class Link extends Parser implements ParserInterface
         $this->page = $page;
         $this->host = $host;
         $this->html = $html;
-        $this->urlParser = new UrlFormatter($host, app('html'));
+        $this->urlParser = new UrlFormatter($host, app('html'), new ParenthesesParser(new SymmetricParenthesesChunks(), self::PARENTHESES_LEVEL));
     }
 
     /**

--- a/app/Services/Parser/Parsers/Link.php
+++ b/app/Services/Parser/Parsers/Link.php
@@ -42,7 +42,7 @@ class Link extends Parser implements ParserInterface
         $this->page = $page;
         $this->host = $host;
         $this->html = $html;
-        $this->urlParser = new UrlFormatter($host);
+        $this->urlParser = new UrlFormatter($host, app('html'));
     }
 
     /**

--- a/app/Services/Parser/Parsers/Parentheses/ParenthesesParser.php
+++ b/app/Services/Parser/Parsers/Parentheses/ParenthesesParser.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Coyote\Services\Parser\Parsers\Parentheses;
+
+use Tests\Feature\Services\Parser\Parsers\Parentheses\ParenthesesParserTest;
+
+/**
+ * If you read {@link ParenthesesParserTest} you will see examples, of how this
+ * class works.
+ *
+ * This class responsibility is to use symmetric or mismatched chunks returned
+ * by {@link SymmetricParenthesesChunks} and "comb" them into valid/invalid
+ * parentheses expressions. It is done in two steps:
+ *  - Combing:
+ *    - Iterates chunks first by pairs (if nestLevel is >= 0).
+ *    - Then, iterates by triplets (if nestLevel is >= 1).
+ *    - Then, iterates chunks by four of each (if nestLevel is >= 2), and so on
+ *      Algorithm complexity is: o(n * c), where:
+ *      - `n` - is the number of chunks, which is number of symmetric parentheses in input string divided by two.
+ *      - `l` - nestLevel
+ *      So for nestLevel=chunks (n=l), complexity is: o(n^2)
+ *    After combing, `l` levels of parentheses should be joined into one. (So for example,
+ *      for nestLevel=6, parentheses nested 7 times won't be parsed).
+ *  - Squashing
+ *    - Joins any two valid adjacent chunks into one, so they can be later for example
+ *       rendered as a single link.
+ */
+class ParenthesesParser
+{
+    /** @var SymmetricParenthesesChunks */
+    private $chunks;
+    /** @var int */
+    private $nestLevel;
+
+    public function __construct(SymmetricParenthesesChunks $chunks, int $nestLevel)
+    {
+        $this->chunks = $chunks;
+        $this->nestLevel = $nestLevel;
+    }
+
+    public function parse(string $content): array
+    {
+        $c = $this->chunks->chunk($content);
+        $c = $this->comb($c, 1);
+        $c = $this->flatMapMismatched($c);
+        $c = $this->comb($c, $this->nestLevel - 1);
+        $c = $this->squashChunks($c);
+        return $c;
+    }
+
+    private function comb(array $elements, int $iterations): array
+    {
+        $result = $elements;
+        for ($i = 0; $i < $iterations; $i++) {
+            $result = $this->performCombIteration($result, $i + 1);
+        }
+        return $result;
+    }
+
+    private function performCombIteration(array $elements, int $nestLevel): array
+    {
+        // for $nestLevel < 0 this method doesn't make any sense
+        // for $nestLevel = 0 this method doesn't have any effect
+        if ($nestLevel < 0) {
+            throw new \InvalidArgumentException();
+        }
+        $result = [];
+        for ($i = 0; $i < count($elements); $i++) {
+            $toComb = join(array_slice($elements, $i, $nestLevel + 1));
+            if ($this->validExpression($toComb)) {
+                $result[] = $toComb;
+                $i += $nestLevel;
+                continue;
+            }
+            $result[] = $elements[$i];
+        }
+        return $result;
+    }
+
+    private function flatMapMismatched(array $elements): array
+    {
+        $result = [];
+        foreach ($elements as $element) {
+            if ($this->validExpression($element)) {
+                $result[] = $element;
+            } else {
+                $result = array_merge($result, pattern('([()])')->split($element));
+            }
+        }
+        return array_values(array_filter($result, 'strlen'));
+    }
+
+    private function squashChunks(array $chunks): array
+    {
+        $result = [];
+        $squashedChunks = null;
+        foreach ($chunks as $chunk) {
+            if ($this->validExpression($chunk)) {
+                $squashedChunks .= $chunk;
+            } else {
+                if ($squashedChunks !== null) {
+                    $result[] = $squashedChunks;
+                    $squashedChunks = null;
+                }
+                $result[] = $chunk;
+            }
+        }
+        if ($squashedChunks !== null) {
+            $result[] = $squashedChunks;
+        }
+        return $result;
+    }
+
+    private function validExpression(string $expression): bool
+    {
+        return mb_substr_count($expression, '(') === mb_substr_count($expression, ')');
+        // Technically, ")(" would also be considered a valid expression,
+        // but `ParenthesesChunks` will not return such chunks.
+    }
+}

--- a/app/Services/Parser/Parsers/Parentheses/ParenthesesParser.php
+++ b/app/Services/Parser/Parsers/Parentheses/ParenthesesParser.php
@@ -40,12 +40,12 @@ class ParenthesesParser
 
     public function parse(string $content): array
     {
-        $c = $this->chunks->chunk($content);
-        $c = $this->comb($c, 1);
-        $c = $this->flatMapMismatched($c);
-        $c = $this->comb($c, $this->nestLevel - 1);
-        $c = $this->squashChunks($c);
-        return $c;
+        $chunks = $this->chunks->chunk($content);
+        $chunks = $this->comb($chunks, 1);
+        $chunks = $this->flatMapMismatched($chunks);
+        $chunks = $this->comb($chunks, $this->nestLevel - 1);
+        $chunks = $this->squashChunks($chunks);
+        return $chunks;
     }
 
     private function comb(array $elements, int $iterations): array

--- a/app/Services/Parser/Parsers/Parentheses/SymmetricParenthesesChunks.php
+++ b/app/Services/Parser/Parsers/Parentheses/SymmetricParenthesesChunks.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Coyote\Services\Parser\Parsers\Parentheses;
+
+use Tests\Feature\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunksTest;
+
+/**
+ * If you read {@link SymmetricParenthesesChunksTest} you will see examples, of how this
+ * class works.
+ *
+ * This class responsibility is to split an arbitrary string into chunks, by parentheses.
+ * The resulting chunks will always have:
+ *  - Symmetric parentheses (e.g. `()`, `(())`, `()()`, etc.)
+ *  - Mismatched parentheses (e.g. `(()`, `())`, etc.)
+ * But will never have asymmetric parentheses (e.g. `)(`, etc.)
+ *
+ * The resulting chunks are used in {@link ParenthesesParser} to "comb" them into actual
+ * valid parenthesis expressions. This class can be thought of as an internal implementation.
+ */
+class SymmetricParenthesesChunks
+{
+    public function chunk(string $content): array
+    {
+        return $this->filterNonNull($this->makeChunks(pattern('([()])')->split($content)));
+    }
+
+    private function makeChunks(array $elements): array
+    {
+        $stack = [];
+        $current = null;
+        $nestLevel = 0;
+        foreach ($elements as $element) {
+            if ($element === '') {
+                continue;
+            }
+            if ($element === '(') {
+                $nestLevel++;
+                $stack[] = $current;
+                $current = $element;
+                continue;
+            }
+            if ($element === ')') {
+                $nestLevel--;
+                if ($nestLevel > 0) {
+                    $current .= $element;
+                    continue;
+                }
+                if ($nestLevel === 0) {
+                    $stack[] = $current . $element;
+                    $current = null;
+                    continue;
+                }
+                if ($nestLevel < 0) {
+                    $stack[] = $current;
+                    $stack[] = $element;
+                    $current = null;
+                    $nestLevel = 0;
+                }
+                continue;
+            }
+            $current .= $element;
+        }
+        $stack[] = $current;
+        return $stack;
+    }
+
+    private function filterNonNull(array $elements): array
+    {
+        return array_values(array_filter($elements, function (?string $element) {
+            return $element !== null;
+        }));
+    }
+}

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -44,7 +44,7 @@ class UrlFormatter
     private function buildLink(string $url): string
     {
         if (Pattern::pcre(self::REGEXP_URL)->test($url)) {
-            return $this->html->link($this->prependSchema($url), $this->truncate($this->quoteUrl($url)));
+            return $this->html->link($this->prependSchema($url), $this->truncate($url));
         }
         return $url;
     }
@@ -72,10 +72,5 @@ class UrlFormatter
     {
         $padding = ($length - mb_strlen($substitute)) / 2;
         return mb_substr($text, 0, $padding) . $substitute . mb_substr($text, -$padding);
-    }
-
-    private function quoteUrl(string $url): string
-    {
-        return htmlspecialchars($url, ENT_QUOTES, 'UTF-8', false); // doesn't app('html') take care of this?
     }
 }

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -3,50 +3,60 @@
 namespace Coyote\Services\Parser\Parsers;
 
 use Collective\Html\HtmlBuilder;
-use TRegx\SafeRegex\Exception\BacktrackLimitPregException;
+use Coyote\Services\Parser\Parsers\Parentheses\ParenthesesParser;
+use Coyote\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunks;
+use TRegx\CleanRegex\Pattern;
 use TRegx\SafeRegex\preg;
 
 class UrlFormatter
 {
     // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
-    private const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
-
+    // modified - removed part with parsing of parentheses, because that's
+    // done by ParenthesesParser
+    private const REGEXP_URL = '~\b(?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)[^\s<>]+[^\s`!(\[\]{};:\'".,<>?«»“”‘’]~i';
+    private const PARENTHESES_LEVEL = 3;
     private const TITLE_LEN = 64;
 
     /** @var string */
     private $host;
     /** @var HtmlBuilder */
     private $html;
+    /** @var ParenthesesParser */
+    private $parser;
 
     public function __construct(string $host, HtmlBuilder $html)
     {
         $this->host = $host;
         $this->html = $html;
+        $this->parser = new ParenthesesParser(new SymmetricParenthesesChunks(), self::PARENTHESES_LEVEL);
     }
 
     public function parse(string $text): string
     {
-        try {
-            return preg::replace_callback(self::REGEXP_URL, function (array $match): string {
-                $url = $match[0];
-                if (pattern('^[\w]+?://', 'i')->fails($url)) {
-                    return $this->processLink('http://' . $url, $url);
-                }
-                return $this->processLink($url, $url);
-            }, $text);
-        } catch (BacktrackLimitPregException $exception) {
-            // regexp posiada buga, nie parsuje poprawnie URL-i jezeli zawiera on (
-            // poki co nie mam rozwiazania na ten problem, dlatego zwracamy nieprzeprasowany tekst
-            // w przypadku bledu
-            // Dokłądniej mówiąc to nie parsuje żadnego urla w poście, jeśli przynajmniej jeden z nich ma (
-            return $text;
-        }
+        return preg::replace_callback(self::REGEXP_URL, function (array $match): string {
+            return $this->processLink($match[0]);
+        }, $text);
     }
 
-    private function processLink(string $url, string $title): string
+    private function processLink(string $url): string
     {
-        $quoted = htmlspecialchars($title, ENT_QUOTES, 'UTF-8', false); // doesn't app('html') take care of this?
-        return $this->html->link($url, $this->truncate($quoted));
+        return join(array_map([$this, 'buildLink'], $this->parser->parse($url)));
+    }
+
+    private function buildLink(string $url): string
+    {
+        if (Pattern::pcre(self::REGEXP_URL)->test($url)) {
+            return $this->html->link($this->prependSchema($url), $this->truncate($this->quoteUrl($url)));
+        }
+        return $url;
+    }
+
+    private function prependSchema(string $url): string
+    {
+        if (pattern('^[\w]+?://', 'i')->fails($url)) {
+            return "http://$url";
+        }
+        return $url;
     }
 
     private function truncate(string $text): string
@@ -64,5 +74,10 @@ class UrlFormatter
     {
         $padding = ($length - mb_strlen($substitute)) / 2;
         return mb_substr($text, 0, $padding) . $substitute . mb_substr($text, -$padding);
+    }
+
+    private function quoteUrl(string $url): string
+    {
+        return htmlspecialchars($url, ENT_QUOTES, 'UTF-8', false); // doesn't app('html') take care of this?
     }
 }

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Coyote\Services\Parser\Parsers;
+
+use Collective\Html\HtmlBuilder;
 
 class UrlFormatter
 {
@@ -11,13 +14,16 @@ class UrlFormatter
 
     /** @var string */
     private $host;
+    /** @var HtmlBuilder */
+    private $html;
 
-    public function __construct(string $host)
+    public function __construct(string $host, HtmlBuilder $html)
     {
         $this->host = $host;
+        $this->html = $html;
     }
 
-    public function parse(string $text):string
+    public function parse(string $text): string
     {
 
         $processed = preg_replace_callback(
@@ -31,7 +37,7 @@ class UrlFormatter
 
                 $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
 
-                return link_to($url, $title);
+                return $this->html->link($url, $title);
             },
             $text
         );

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -7,10 +7,10 @@ use Collective\Html\HtmlBuilder;
 class UrlFormatter
 {
     // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
-    const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
+    private const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
 
-    const TITLE_LEN = 64;
-    const TITLE_DOTS = '[...]';
+    private const TITLE_LEN = 64;
+    private const TITLE_DOTS = '[...]';
 
     /** @var string */
     private $host;
@@ -53,15 +53,9 @@ class UrlFormatter
         return $text;
     }
 
-    /**
-     * @param string $text
-     * @param int $length
-     * @param string $dots
-     * @return string
-     */
-    private function truncate(string $text, int $length = self::TITLE_LEN, string $dots = self::TITLE_DOTS): string
+    private function truncate(string $text): string
     {
-        if (mb_strlen($text) < $length) {
+        if (mb_strlen($text) < self::TITLE_LEN) {
             return $text;
         }
 
@@ -69,10 +63,10 @@ class UrlFormatter
             return $text;
         }
 
-        $padding = ($length - mb_strlen($dots)) / 2;
+        $padding = (self::TITLE_LEN - mb_strlen(self::TITLE_DOTS)) / 2;
 
         $result = mb_substr($text, 0, $padding);
-        $result .= $dots;
+        $result .= self::TITLE_DOTS;
         $result .= mb_substr($text, -$padding);
 
         return $result;

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -58,12 +58,12 @@ class UrlFormatter
             return $text;
         }
 
-        $padding = (self::TITLE_LEN - mb_strlen(self::TITLE_DOTS)) / 2;
+        return $this->truncateToLengthWith($text, self::TITLE_LEN, self::TITLE_DOTS);
+    }
 
-        $result = mb_substr($text, 0, $padding);
-        $result .= self::TITLE_DOTS;
-        $result .= mb_substr($text, -$padding);
-
-        return $result;
+    private function truncateToLengthWith(string $text, int $length, string $substitute): string
+    {
+        $padding = ($length - mb_strlen($substitute)) / 2;
+        return mb_substr($text, 0, $padding) . $substitute . mb_substr($text, -$padding);
     }
 }

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -12,7 +12,6 @@ class UrlFormatter
     private const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
 
     private const TITLE_LEN = 64;
-    private const TITLE_DOTS = '[...]';
 
     /** @var string */
     private $host;
@@ -28,16 +27,12 @@ class UrlFormatter
     public function parse(string $text): string
     {
         try {
-            return preg::replace_callback(self::REGEXP_URL, function ($match) {
+            return preg::replace_callback(self::REGEXP_URL, function (array $match): string {
                 $url = $match[0];
-
-                if (!preg_match('#^[\w]+?://.*?#i', $url)) {
-                    $url = 'http://' . $url;
+                if (pattern('^[\w]+?://', 'i')->fails($url)) {
+                    return $this->processLink('http://' . $url, $url);
                 }
-
-                $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
-
-                return $this->html->link($url, $title);
+                return $this->processLink($url, $url);
             }, $text);
         } catch (BacktrackLimitPregException $exception) {
             // regexp posiada buga, nie parsuje poprawnie URL-i jezeli zawiera on (
@@ -48,17 +43,21 @@ class UrlFormatter
         }
     }
 
+    private function processLink(string $url, string $title): string
+    {
+        $quoted = htmlspecialchars($title, ENT_QUOTES, 'UTF-8', false); // doesn't app('html') take care of this?
+        return $this->html->link($url, $this->truncate($quoted));
+    }
+
     private function truncate(string $text): string
     {
         if (mb_strlen($text) < self::TITLE_LEN) {
             return $text;
         }
-
         if ($this->host === parse_url($text, PHP_URL_HOST)) {
             return $text;
         }
-
-        return $this->truncateToLengthWith($text, self::TITLE_LEN, self::TITLE_DOTS);
+        return $this->truncateToLengthWith($text, self::TITLE_LEN, '[...]');
     }
 
     private function truncateToLengthWith(string $text, int $length, string $substitute): string

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -4,7 +4,6 @@ namespace Coyote\Services\Parser\Parsers;
 
 use Collective\Html\HtmlBuilder;
 use Coyote\Services\Parser\Parsers\Parentheses\ParenthesesParser;
-use Coyote\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunks;
 use TRegx\CleanRegex\Pattern;
 use TRegx\SafeRegex\preg;
 
@@ -14,7 +13,6 @@ class UrlFormatter
     // modified - removed part with parsing of parentheses, because that's
     // done by ParenthesesParser
     private const REGEXP_URL = '~\b(?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)[^\s<>]+[^\s`!(\[\]{};:\'".,<>?«»“”‘’]~i';
-    private const PARENTHESES_LEVEL = 3;
     private const TITLE_LEN = 64;
 
     /** @var string */
@@ -24,11 +22,11 @@ class UrlFormatter
     /** @var ParenthesesParser */
     private $parser;
 
-    public function __construct(string $host, HtmlBuilder $html)
+    public function __construct(string $host, HtmlBuilder $html, ParenthesesParser $parser)
     {
         $this->host = $host;
         $this->html = $html;
-        $this->parser = new ParenthesesParser(new SymmetricParenthesesChunks(), self::PARENTHESES_LEVEL);
+        $this->parser = $parser;
     }
 
     public function parse(string $text): string

--- a/app/Services/Parser/Parsers/UrlFormatter.php
+++ b/app/Services/Parser/Parsers/UrlFormatter.php
@@ -1,0 +1,74 @@
+<?php
+namespace Coyote\Services\Parser\Parsers;
+
+class UrlFormatter
+{
+    // http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+    const REGEXP_URL = '#(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))#u';
+
+    const TITLE_LEN = 64;
+    const TITLE_DOTS = '[...]';
+
+    /** @var string */
+    private $host;
+
+    public function __construct(string $host)
+    {
+        $this->host = $host;
+    }
+
+    public function parse(string $text):string
+    {
+
+        $processed = preg_replace_callback(
+            self::REGEXP_URL,
+            function ($match) {
+                $url = $match[0];
+
+                if (!preg_match('#^[\w]+?://.*?#i', $url)) {
+                    $url = 'http://' . $url;
+                }
+
+                $title = $this->truncate(htmlspecialchars($match[0], ENT_QUOTES, 'UTF-8', false));
+
+                return link_to($url, $title);
+            },
+            $text
+        );
+
+        // regexp posiada buga, nie parsuje poprawnie URL-i jezeli zawiera on (
+        // poki co nie mam rozwiazania na ten problem, dlatego zwracamy nieprzeprasowany tekst
+        // w przypadku bledu
+        // Dokłądniej mówiąc to nie parsuje żadnego urla w poście, jeśli przynajmniej jeden z nich ma (
+        if (preg_last_error() === PREG_NO_ERROR) {
+            return $processed;
+        }
+
+        return $text;
+    }
+
+    /**
+     * @param string $text
+     * @param int $length
+     * @param string $dots
+     * @return string
+     */
+    private function truncate(string $text, int $length = self::TITLE_LEN, string $dots = self::TITLE_DOTS): string
+    {
+        if (mb_strlen($text) < $length) {
+            return $text;
+        }
+
+        if ($this->host === parse_url($text, PHP_URL_HOST)) {
+            return $text;
+        }
+
+        $padding = ($length - mb_strlen($dots)) / 2;
+
+        $result = mb_substr($text, 0, $padding);
+        $result .= $dots;
+        $result .= mb_substr($text, -$padding);
+
+        return $result;
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/Parentheses/ParenthesesParserTest.php
+++ b/tests/Feature/Services/Parser/Parsers/Parentheses/ParenthesesParserTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Services\Parser\Parsers\Parentheses;
+
+use Coyote\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunks;
+use Coyote\Services\Parser\Parsers\Parentheses\ParenthesesParser;
+use PHPUnit\Framework\TestCase;
+
+class ParenthesesParserTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider cases
+     */
+    public function shouldMakeChunks(string $input, array $expected)
+    {
+        // given
+        $chunks = new ParenthesesParser(new SymmetricParenthesesChunks(), 4);
+
+        // when
+        $result = $chunks->parse($input);
+
+        // then
+        $this->assertSame($expected, $result);
+    }
+
+    public function cases(): array
+    {
+        return [
+            # Corner cases
+            ['', []],
+            ['(', ['(']],
+            [')', [')']],
+            ['(((', ['(', '(', '(']],
+            [')))', [')', ')', ')']],
+
+            # Regular cases
+            'link'                  => ['link', ['link']],
+            'link + ('              => ['link(', ['link', '(']],
+            'link + (()'            => ['foo(bar(lorem)', ['foo', '(', 'bar(lorem)']],
+            'link()'                => ['link(path)', ['link(path)']],
+            'link() + ('            => ['link(path)(', ['link(path)', '(']],
+            'link() + )'            => ['link(path))', ['link(path)', ')']],
+            'link() + ))'           => ['link()foo)bar)lorem', ['link()foo', ')', 'bar', ')', 'lorem']],
+            'link()()'              => ['link(foo)(bar)', ['link(foo)(bar)']],
+            'link()() + )'          => ['link(foo)(bar))', ['link(foo)(bar)', ')']],
+
+            # PHP stupid type mixing
+            'link(0'                => ['link(0', ['link', '(', '0']],
+
+            # Multiple links
+            'link() + ) + link()'   => ['link(foo))link(bar)', ['link(foo)', ')', 'link(bar)']],
+
+            # Nesting
+            'link + ((()'           => ['link (((bar)', ['link ', '(', '(', '(bar)']],
+            '(link)'                => ['(link)', ['(link)']],
+
+            # Business cases
+            'malformed parentheses' => ['http://4pr.net/Forum/(tex(t)', ['http://4pr.net/Forum/', '(', 'tex(t)']],
+            'enclosed links'        => ['http://4pr.net/Forum(https://4pr.net/Forum', ['http://4pr.net/Forum', '(', 'https://4pr.net/Forum']],
+
+            # Unhappy consequence
+            // These examples are partially valid links, but are split into chunks. This is inconvenient, but
+            // is a necessary consequence of a linear algorithm. At the second iteration (`(f`), we don't know
+            // if the last chunk will be `)` or `(`? So we can't assume the chunk will contain a valid expression,
+            // or not. We'll assume it's an invalid chunk, and let ParenthesesParser to handle it.
+            'link(())() + )'        => ['link(f(oo))(bar))', ['link(f(oo))(bar)', ')']],
+            'link((()))() + )'      => ['link(f(o(o))(xd))(bar))', ['link(f(o(o))(xd))(bar)', ')']],
+            'link(()) + ( + link()' => ['link((foo)) (link(bar)', ['link((foo)) ', '(', 'link(bar)']],
+        ];
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/Parentheses/SymmetricParenthesesChunksTest.php
+++ b/tests/Feature/Services/Parser/Parsers/Parentheses/SymmetricParenthesesChunksTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Services\Parser\Parsers\Parentheses;
+
+use Coyote\Services\Parser\Parsers\Parentheses\SymmetricParenthesesChunks;
+use PHPUnit\Framework\TestCase;
+
+class SymmetricParenthesesChunksTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider cases
+     */
+    public function shouldMakeChunks(string $input, array $expected)
+    {
+        // given
+        $chunks = new SymmetricParenthesesChunks();
+
+        // when
+        $result = $chunks->chunk($input);
+
+        // then
+        $this->assertSame($expected, $result);
+    }
+
+    public function cases(): array
+    {
+        return [
+            # Corner cases
+            ['', []],
+            ['(', ['(']],
+            [')', [')']],
+            ['(((', ['(', '(', '(']],
+            [')))', [')', ')', ')']],
+
+            # Regular cases
+            'link'                  => ['link', ['link']],
+            'link + ('              => ['link(', ['link', '(']],
+            'link + (()'            => ['foo(bar(lorem)', ['foo', '(bar', '(lorem)']],
+            'link()'                => ['link(path)', ['link', '(path)']],
+            'link() + ('            => ['link(path)(', ['link', '(path)', '(']],
+            'link() + )'            => ['link(path))', ['link', '(path)', ')']],
+            'link() + ))'           => ['link()foo)bar)lorem', ['link', '()', 'foo', ')', 'bar', ')', 'lorem']],
+            'link()()'              => ['link(foo)(bar)', ['link', '(foo)', '(bar)']],
+            'link()() + )'          => ['link(foo)(bar))', ['link', '(foo)', '(bar)', ')']],
+
+            # Multiple links
+            'link() + ) + link()'   => ['link(foo))link(bar)', ['link', '(foo)', ')', 'link', '(bar)']],
+            'link() + ( + link()'   => ['link(foo)(link(bar)', ['link', '(foo)', '(link', '(bar)']],
+
+            # Nesting
+            'link + ((()'           => ['link (((bar)', ['link ', '(', '(', '(bar)']],
+            '(link)'                => ['(link)', ['(link)']],
+
+            # Business cases
+            'malformed parentheses' => ['http://4pr.net/Forum/(tex(t)', ['http://4pr.net/Forum/', '(tex', '(t)']],
+            'enclosed links'        => ['http://4pr.net/Forum(https://4pr.net/Forum', ['http://4pr.net/Forum', '(https://4pr.net/Forum']],
+
+            # Unhappy consequence
+            // These examples are partially valid links, but are split into chunks. This is inconvenient, but
+            // is a necessary consequence of a linear algorithm. At the second iteration (`(f`), we don't know
+            // if the last chunk will be `)` or `(`? So we can't assume the chunk will contain a valid expression,
+            // or not. We'll assume it's an invalid chunk, and let ParenthesesParser to handle it.
+            'link(())() + )'        => ['link(f(oo))(bar))', ['link', '(f', '(oo))', '(bar)', ')']],
+            'link((()))() + )'      => ['link(f(o(o)))(bar))', ['link', '(f', '(o', '(o)))', '(bar)', ')']],
+            'link(()) + ( + link()' => ['link((foo)) (link(bar)', ['link', '(', '(foo))', ' ', '(link', '(bar)']],
+        ];
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -100,6 +100,22 @@ class UrlFormatterTest extends TestCase
         $this->assertEquals('<a>4pr.net/Forum/</a>(tex(t)', $result);
     }
 
+    /**
+     * @test
+     */
+    public function shouldHandleCatastrophicBacktracking_withUnmatchedParenthesis()
+    {
+        // given
+        $errorProneLink = 'http://4pr.net/Forum/(long_long_long_long_long';
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+
+        // when
+        $result = $formatter->parse($errorProneLink);
+
+        // then
+        $this->assertEquals('<a>http://4pr.net/Forum/</a>(long_long_long_long_long', $result);
+    }
+
     private function html(string $expectedHref = null): HtmlBuilder
     {
         /** @var HtmlBuilder|MockObject $html */

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Services\Parser\Parsers;
+
+use Collective\Html\HtmlBuilder;
+use Coyote\Services\Parser\Parsers\UrlFormatter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UrlFormatterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldParseLink()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldTruncateLongLink()
+    {
+        // given
+        $longUrl = 'https://scrutinizer-ci.com/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
+        $formatter = new UrlFormatter('', $this->html($longUrl));
+
+        // when
+        $result = $formatter->parse("link: $longUrl");
+
+        // then
+        $this->assertEquals('link: <a>https://scrutinizer-ci.com/g/[...]8-ef73-4167-8092-424a57a8e66d</a>', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldIncludeParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(text) text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(text)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldIncludeNestedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(t(ex)t)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(t(ex)t) text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(t(ex)t)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotIncludeUnmatchedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum/(text)( text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum/(text)</a>( text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotIncludeUnmatchedNestedParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+
+        // when
+        $result = $formatter->parse('4pr.net/Forum/(tex(t)');
+
+        // then
+        $this->assertEquals('<a>4pr.net/Forum/</a>(tex(t)', $result);
+    }
+
+    private function html(string $expectedHref = null): HtmlBuilder
+    {
+        /** @var HtmlBuilder|MockObject $html */
+        $html = $this->createMock(HtmlBuilder::class);
+        $html
+            ->expects($this->once())
+            ->method('link')
+            ->will($this->returnCallback(function (string $href, string $title) use ($expectedHref): string {
+                if ($expectedHref) {
+                    $this->assertEquals($expectedHref, $href, 'Failed asserting that parsed link contains expected href attribute');
+                }
+                return "<a>$title</a>";
+            }));
+        return $html;
+    }
+}

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -43,6 +43,22 @@ class UrlFormatterTest extends TestCase
     /**
      * @test
      */
+    public function shouldNotTruncateLongLink_hostLink()
+    {
+        // given
+        $longUrl = 'https://4pr.net/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
+        $formatter = new UrlFormatter('4pr.net', $this->html($longUrl));
+
+        // when
+        $result = $formatter->parse("link: $longUrl");
+
+        // then
+        $this->assertEquals('link: <a>https://4pr.net/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d</a>', $result);
+    }
+
+    /**
+     * @test
+     */
     public function shouldIncludeParenthesis()
     {
         // given

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -190,7 +190,7 @@ class UrlFormatterTest extends TestCase
                 if ($expectedHref) {
                     $this->assertEquals($expectedHref, $href, 'Failed asserting that parsed link contains expected href attribute');
                 }
-                return "<a>$title</a>";
+                return '<a>' . htmlentities($title) . '</a>'; // We're mocking HtmlBuilder and trust it will encode the title
             }));
         return $html;
     }

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -104,6 +104,21 @@ class UrlFormatterTest extends TestCase
     /**
      * @test
      */
+    public function shouldHandleLinksSeparatedByAnOpenParenthesis_ifItResemblesADomain()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum', 2));
+
+        // when
+        $result = $formatter->parse('4pr.net/Forum(4pr.net/Forum');
+
+        // then
+        $this->assertEquals('<a>4pr.net/Forum</a>(<a>4pr.net/Forum</a>', $result);
+    }
+
+    /**
+     * @test
+     */
     public function shouldIncludeNestedParenthesis()
     {
         // given

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -27,6 +27,21 @@ class UrlFormatterTest extends TestCase
     /**
      * @test
      */
+    public function shouldParseLink_htmlEntities()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum&param'));
+
+        // when
+        $result = $formatter->parse('text 4pr.net/Forum&param text');
+
+        // then
+        $this->assertEquals('text <a>4pr.net/Forum&amp;param</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
     public function shouldTruncateLongLink()
     {
         // given
@@ -69,6 +84,21 @@ class UrlFormatterTest extends TestCase
 
         // then
         $this->assertEquals('text <a>4pr.net/Forum/(text)</a> text', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldHandleLinksSeparatedByAnOpenParenthesis()
+    {
+        // given
+        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum', 2));
+
+        // when
+        $result = $formatter->parse('4pr.net/Forum(https://4pr.net/Forum');
+
+        // then
+        $this->assertEquals('<a>4pr.net/Forum</a>(<a>4pr.net/Forum</a>', $result);
     }
 
     /**
@@ -132,12 +162,12 @@ class UrlFormatterTest extends TestCase
         $this->assertEquals('<a>http://4pr.net/Forum/</a>(long_long_long_long_long', $result);
     }
 
-    private function html(string $expectedHref = null): HtmlBuilder
+    private function html(string $expectedHref = null, int $expectedInvocations = 1): HtmlBuilder
     {
         /** @var HtmlBuilder|MockObject $html */
         $html = $this->createMock(HtmlBuilder::class);
         $html
-            ->expects($this->once())
+            ->expects($this->exactly($expectedInvocations))
             ->method('link')
             ->will($this->returnCallback(function (string $href, string $title) use ($expectedHref): string {
                 if ($expectedHref) {

--- a/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
+++ b/tests/Feature/Services/Parser/Parsers/UrlFormatterTest.php
@@ -15,7 +15,7 @@ class UrlFormatterTest extends TestCase
     public function shouldParseLink()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum'));
 
         // when
         $result = $formatter->parse('text 4pr.net/Forum text');
@@ -30,7 +30,7 @@ class UrlFormatterTest extends TestCase
     public function shouldParseLink_htmlEntities()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum&param'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum&param'));
 
         // when
         $result = $formatter->parse('text 4pr.net/Forum&param text');
@@ -46,7 +46,7 @@ class UrlFormatterTest extends TestCase
     {
         // given
         $longUrl = 'https://scrutinizer-ci.com/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
-        $formatter = new UrlFormatter('', $this->html($longUrl));
+        $formatter = new UrlFormatter('', $this->htmlExpect($longUrl));
 
         // when
         $result = $formatter->parse("link: $longUrl");
@@ -62,7 +62,7 @@ class UrlFormatterTest extends TestCase
     {
         // given
         $longUrl = 'https://4pr.net/g/adam-boduch/coyote/inspections/8778b728-ef73-4167-8092-424a57a8e66d';
-        $formatter = new UrlFormatter('4pr.net', $this->html($longUrl));
+        $formatter = new UrlFormatter('4pr.net', $this->htmlExpect($longUrl));
 
         // when
         $result = $formatter->parse("link: $longUrl");
@@ -77,7 +77,7 @@ class UrlFormatterTest extends TestCase
     public function shouldIncludeParenthesis()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum/(text)'));
 
         // when
         $result = $formatter->parse('text 4pr.net/Forum/(text) text');
@@ -92,13 +92,13 @@ class UrlFormatterTest extends TestCase
     public function shouldHandleLinksSeparatedByAnOpenParenthesis()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum', 2));
+        $formatter = new UrlFormatter('', $this->html());
 
         // when
         $result = $formatter->parse('4pr.net/Forum(https://4pr.net/Forum');
 
         // then
-        $this->assertEquals('<a>4pr.net/Forum</a>(<a>4pr.net/Forum</a>', $result);
+        $this->assertEquals('<a>4pr.net/Forum</a>(<a>https://4pr.net/Forum</a>', $result);
     }
 
     /**
@@ -107,7 +107,7 @@ class UrlFormatterTest extends TestCase
     public function shouldHandleLinksSeparatedByAnOpenParenthesis_ifItResemblesADomain()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum', 2));
+        $formatter = new UrlFormatter('', $this->html());
 
         // when
         $result = $formatter->parse('4pr.net/Forum(4pr.net/Forum');
@@ -122,7 +122,7 @@ class UrlFormatterTest extends TestCase
     public function shouldIncludeNestedParenthesis()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(t(ex)t)'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum/(t(ex)t)'));
 
         // when
         $result = $formatter->parse('text 4pr.net/Forum/(t(ex)t) text');
@@ -137,7 +137,7 @@ class UrlFormatterTest extends TestCase
     public function shouldNotIncludeUnmatchedParenthesis()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/(text)'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum/(text)'));
 
         // when
         $result = $formatter->parse('text 4pr.net/Forum/(text)( text');
@@ -152,7 +152,7 @@ class UrlFormatterTest extends TestCase
     public function shouldNotIncludeUnmatchedNestedParenthesis()
     {
         // given
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum/'));
 
         // when
         $result = $formatter->parse('4pr.net/Forum/(tex(t)');
@@ -168,7 +168,7 @@ class UrlFormatterTest extends TestCase
     {
         // given
         $errorProneLink = 'http://4pr.net/Forum/(long_long_long_long_long';
-        $formatter = new UrlFormatter('', $this->html('http://4pr.net/Forum/'));
+        $formatter = new UrlFormatter('', $this->htmlExpect('http://4pr.net/Forum/'));
 
         // when
         $result = $formatter->parse($errorProneLink);
@@ -177,12 +177,12 @@ class UrlFormatterTest extends TestCase
         $this->assertEquals('<a>http://4pr.net/Forum/</a>(long_long_long_long_long', $result);
     }
 
-    private function html(string $expectedHref = null, int $expectedInvocations = 1): HtmlBuilder
+    private function htmlExpect(string $expectedHref = null): HtmlBuilder
     {
         /** @var HtmlBuilder|MockObject $html */
         $html = $this->createMock(HtmlBuilder::class);
         $html
-            ->expects($this->exactly($expectedInvocations))
+            ->expects($this->once())
             ->method('link')
             ->will($this->returnCallback(function (string $href, string $title) use ($expectedHref): string {
                 if ($expectedHref) {
@@ -190,6 +190,16 @@ class UrlFormatterTest extends TestCase
                 }
                 return "<a>$title</a>";
             }));
+        return $html;
+    }
+
+    private function html(): HtmlBuilder
+    {
+        /** @var HtmlBuilder|MockObject $html */
+        $html = $this->createMock(HtmlBuilder::class);
+        $html->method('link')->will($this->returnCallback(function (string $href, string $title): string {
+            return "<a>$title</a>";
+        }));
         return $html;
     }
 }


### PR DESCRIPTION
Koniec końców:
 - Wydzieliłem parsowanie linków z klasy `Link` do `UrlFormatter`, tak że w `Link` została inna logika dot. budowania linków, ale samo "wyciąganie" linków jest w `UrlFormatter`.
 - Regexp który zosatał tam użyty wykonywał wykładnicze obliczenia, szukając zagnieżdżeń dla każdego kolejnego znaku (więc np `(aaaaaaaaaaaaaa` powodował wyczerpanie limitu).
 - Przerobiłem algorytm z regexpów na proceduralną szukajkę (`for`, `if`):
   - Wykonuje wykładnicze operacje, ale nie dla każdegoznaku (np `(aa`) tylko dla nawiasów, czyli tylko `((((((((((((((((((((((((((` spowodowałby błąd, `(((((((((aaaaaaaaaaa` nie). 
   - Algorytm sprawdza tyle poziomów zagnieżdżenia ile jest ustawione w stałej: `PARENTHESES_LEVEL` *(tzn link `4p.net/(((a)))` zostanie rozpoznany, ale `4p.net/((((a))))` nie)*. Nawet przy 15 poziomach nie udało mi się drastycznie zmniejszyć performance'u, nie udało mi się też napisać testu pod to żeby algorytm nie rozwiązał tylu zagnieżdżeń. Myślę że nawet 25 zagnieżdżeń nawiasów nie będzie problemem, przez to że to tylko 25 iteracji algorytmu. 
 - Algorytm oparty na regexpach ogarniał 2 poziomy nawiasów, więc ja w tym prze ustawiłem 3 poziomy. Można zmienić na 2 żeby było bez zmian. (tzn wcześniej nie działały 3 poziomy, i można zrobić żeby teraz też nie działały).

Jak działa algorytm:
 - Łapie wszystko co jest linkiem, nawet jak ma pomieszane `(` oraz `)`.
 - Dzieli go na kawałki (split na `[()]`)
 - Wykonuje pierwszą literację łącząc każdy pojedyńczy level nawiasów w jeden.
 - Jeśli trzeba, to wykonuje drugą iteracje, łącząc każdy podwójny level nawiasów w jeden.
 - Jeśli trzeba, to wykonuje trzecią iteracje, łącząc każdy potrójniy level nawiasów w jeden.
 - Wykonuje iteracje łącząc `n`-leveli w jeden, maksymalnie do stałej `PARENTHESES_LEVEL`.
 - Mając wszystkie chunki, te które są poprawnym linkiem (np zaczyna się od `https://`) są zamieniane w markup html. Reszta zostaje nie zmieniona.

Stała `PARENTHESES_LEVEL` = 0 sprawia że nie ma nawiasów w linkach.

Napisałem 11 unit testów do parsera linków, 23 unit-case'y do iteracyjnego łączenia linków i te same unit-casy do splitowania linków przez nawiasy.

Szczególnie prosiłbym o review klasy `UrlFormatterTest` w której są testy tego jak linki powinny być budowane. Prosiłbym też o odpalenie tego kodu lokalnie u siebie, na wypadek gdybym popełnił jakiś błąd.