### PR TITLE
[Minor] Typo and helper

### DIFF
--- a/app/Http/Validators/TagValidator.php
+++ b/app/Http/Validators/TagValidator.php
@@ -36,7 +36,7 @@ class TagValidator
      */
     public function validateTag($attribute, $value)
     {
-        return (bool) preg_match('/' . self::REGEXP . '/', trim($value));
+        return pattern(self::REGEXP)->test(trim($value));
     }
 
     /**

--- a/tests/Feature/Services/Helpers/DateDifferenceTest.php
+++ b/tests/Feature/Services/Helpers/DateDifferenceTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class DateDifferenceTest extends TestCase
 {
-    use TestCaronLocale;
+    use TestCarbonLocale;
 
     /**
      * @test

--- a/tests/Feature/Services/Helpers/TestCarbonLocale.php
+++ b/tests/Feature/Services/Helpers/TestCarbonLocale.php
@@ -4,7 +4,7 @@ namespace Tests\Feature\Services\Helpers;
 
 use Carbon\Carbon;
 
-trait TestCaronLocale
+trait TestCarbonLocale
 {
     /** @var string */
     private $locale;


### PR DESCRIPTION
I think it was supposed to be `TestCarbonLocale` ;)

About the `pattern()->test()`, I suggested it because it returns `bool` and doesn't need delimiters.