### PR TITLE
Mikroblogi: dymek pod linkiem

### DIFF
--- a/resources/sass/components/microblog/_microblog.scss
+++ b/resources/sass/components/microblog/_microblog.scss
@@ -60,7 +60,7 @@
 .show-more {
   position: absolute;
   bottom: 0;
-  z-index: 100;
+  z-index: 9;
   display: none;
 }
 


### PR DESCRIPTION
Mikroblogi: po najechaniu na liczbę głosów dymek (`z-index: 10` w bibliotece) z głosującymi pojawiał się pod `.show-more` (`z-index: 100`). Dla `.show-more` wartość >= 1 wystarczy by wyświetlać się prawidłowo.