### PR TITLE
Add #box-forum #stream padding-left:15px on sm

### DIFF
--- a/resources/sass/pages/_homepage.scss
+++ b/resources/sass/pages/_homepage.scss
@@ -56,6 +56,10 @@
     height: 365px;
     position: relative;
     overflow: hidden;
+
+    @include media-breakpoint-down(sm) {
+      padding-left: 15px;
+    }
   }
 
   .overview {


### PR DESCRIPTION
Tak wyglądają komenterze na rozdzielczościach `xs` oraz `sm`:
![image](https://user-images.githubusercontent.com/13367735/116916537-c0adb180-ac4d-11eb-8554-8fd204f56fc5.png)

Po zmienie:
![image](https://user-images.githubusercontent.com/13367735/116916547-c5726580-ac4d-11eb-8330-2410f5b8f0ae.png)
