### PR TITLE
Uruchamianie testów jednostkowych z Windowsa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,16 @@ app/Plugins/*
 .vagrant
 .data
 Vagrantfile
-/.composer
 /public/css/*
 /public/js/*
+
+# PhpUnit
+.phpunit.result.cache
+
+# Composer
+/.composer
+composer.phar
+
+# Secrets
+storage/oauth-private.key
+storage/oauth-public.key

--- a/app/Providers/RepositoryServiceProvider.php
+++ b/app/Providers/RepositoryServiceProvider.php
@@ -30,9 +30,8 @@ class RepositoryServiceProvider extends ServiceProvider
 
         $files = (new Filesystem())->allFiles(app_path('Repositories/Contracts'));
 
-        /** @var \SplFileInfo $file */
         foreach ($files as $file) {
-            $path = str_replace(app_path() . '/', '', $file->getPathname());
+            $path = str_replace(app_path() . DIRECTORY_SEPARATOR, '', $file->getPathname());
             $this->provides[] = 'Coyote\\' . str_replace('/', '\\', substr($path, 0, -4));
         }
     }


### PR DESCRIPTION
poprzez użycie 
```php
$path = str_replace(app_path() . '/', '', $file->getPathname());
```

Ładowanie repozytoriów w testach jednostkowych działało tylko na maszynach w których `/` jest separatorem plików - na Windowsie testy nie działają.