### PR TITLE
Usunięto błędną informację w Markdown nt. <tt>

### DIFF
--- a/resources/js/components/forms/markdown.vue
+++ b/resources/js/components/forms/markdown.vue
@@ -161,7 +161,7 @@
             <h2>Znaczniki HTML</h2>
 
             <p>Dozwolone jest używanie podstawowych znaczników HTML: &lt;a&gt;, &lt;b&gt;, &lt;i&gt;, &lt;del&gt;, &lt;strong&gt;,
-              &lt;tt&gt;, &lt;dfn&gt;, &lt;ins&gt;, &lt;pre&gt;, &lt;blockquote&gt;, &lt;hr&gt;, &lt;sub&gt;, &lt;sup&gt;, &lt;img&gt;</p>
+              &lt;dfn&gt;, &lt;ins&gt;, &lt;pre&gt;, &lt;blockquote&gt;, &lt;hr&gt;, &lt;sub&gt;, &lt;sup&gt;, &lt;img&gt;</p>
 
             <h2>Indeks górny oraz dolny</h2>
 


### PR DESCRIPTION
W instrukji markdown jest napisane że `<tt>` jest wspierany, podczas gdy tak na prawdę nie jest. Poza tym `<tt>` jest deprecated w HTML 5.

![image](https://user-images.githubusercontent.com/13367735/143679243-04b2578c-7dc5-494b-8e2b-beac97de1b7a.png)
