### PR TITLE
Use Pattern::template() for masks in Censore

### DIFF
--- a/app/Services/Parser/Parsers/Censore.php
+++ b/app/Services/Parser/Parsers/Censore.php
@@ -3,29 +3,14 @@
 namespace Coyote\Services\Parser\Parsers;
 
 use Coyote\Repositories\Contracts\WordRepositoryInterface as WordRepository;
+use TRegx\CleanRegex\Pattern;
 
-/**
- * Class Censore
- */
 class Censore extends Parser implements ParserInterface
 {
-    /**
-     * @var WordRepository
-     */
-    private $word;
-
-    /**
-     * @param WordRepository $word
-     */
-    public function __construct(WordRepository $word)
+    public function __construct(private WordRepository $word)
     {
-        $this->word = $word;
     }
 
-    /**
-     * @param string $text
-     * @return string
-     */
     public function parse(string $text): string
     {
         static $result;
@@ -38,8 +23,11 @@ class Censore extends Parser implements ParserInterface
         }
         $words = [];
 
+        $template = Pattern::template('(?<![\p{L}\p{N}_])@(?![\p{L}\p{N}_])', 'iu');
+
         foreach ($result as $row) {
-            $word = '#(?<![\p{L}\p{N}_])' . str_replace('\*', '(\p{L}*?)', preg_quote($row->word)) . '(?![\p{L}\p{N}_])#iu';
+            $pattern = $template->mask($row->word, ['*' => '(\p{L}*?)']);
+            $word = $pattern->delimited();
             $words[$word] = $row->replacement;
         }
 


### PR DESCRIPTION
Zauważyłem, że w klasie `Censore` chyba chodzi o zrobienie maski? Że w modelu `Word`, w atrybucie `word` mogą być słowa, które mają `*`, i one mają być interpretowane jako `\p{L}*?` w wyrażeniu, ale same słowa oprócz gwiazdki jako zwykłe słowo?

Bo jeśli tak, to dokładnie po tak działa `Pattern::template()->mask()` z libki.

Pytanie tylko czy ma sens ten kod i czy się podoba?