### PR TITLE
Sugestia: Update kodu `inline`

### DIFF
--- a/resources/sass/core/_code.scss
+++ b/resources/sass/core/_code.scss
@@ -80,6 +80,7 @@ pre {
 /* Inline code */
 :not(pre) > code {
   padding: .1em;
+  box-shadow: 0 0 3px -1px grey;
   border-radius: .3em;
   white-space: normal;
 }

--- a/resources/sass/helpers/_variables.scss
+++ b/resources/sass/helpers/_variables.scss
@@ -9,7 +9,6 @@ $danger: #d9534f;
 $body-bg: #fafafa;
 $text-color: #333; // @deprecated
 $body-color: #333;
-$code-color: #d7661c;
 
 // bootstrap 3 backward compatibility
 $gray: #555;


### PR DESCRIPTION
Wyraźniejszy kolor w poście, mniej wyraźny w cytacie, cień, brak pomarańczowego.

Przed i po:

![image](https://user-images.githubusercontent.com/13367735/153637828-d5326e0e-26d4-43e5-a541-379e22c33712.png)
