### PR TITLE
Poprawa obrazków w cytatach w postach 

### DIFF
--- a/resources/sass/components/forum/_post.scss
+++ b/resources/sass/components/forum/_post.scss
@@ -143,6 +143,12 @@
   table {
     @extend .table-responsive-sm;
   }
+
+  blockquote {
+    img {
+      opacity: 35%;
+    }
+  }
 }
 
 .edit-info {

--- a/resources/sass/components/forum/_post.scss
+++ b/resources/sass/components/forum/_post.scss
@@ -148,6 +148,10 @@
     img {
       opacity: 35%;
     }
+
+    pre.line-numbers {
+      opacity: 50%;
+    }
   }
 }
 


### PR DESCRIPTION
Obecnie obrazki pokazują się "normalnie" w cytatach, co sprawia wrażenie że są "wybite" ponieważ tekst dookoła jest zdesaturowany. Żeby zachować spójność obrazki również powinny.

## Aktualnie:
![image](https://user-images.githubusercontent.com/13367735/197171057-aa786775-f105-469c-9aa9-dc885ba197fd.png)

## Po zmianie:
![image](https://user-images.githubusercontent.com/13367735/197171078-34378de3-94e4-458f-a259-77c141fd8f26.png)

